### PR TITLE
Added extra array to be used for installing packages globally

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ centos_releases:
 unconfigured_packages:
  - ""
 
+unconfigured_packages_global:
+ - ""
+
 remove_packages:
  - ""
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -25,6 +25,11 @@
   with_items: unconfigured_packages | default({})
   when: unconfigured_packages.0 != ""
 
+- name: install globally software that do not need extra configuration
+  yum: name={{ item }} state=present
+  with_items: unconfigured_packages_global | default({})
+  when: unconfigured_packages_global.0 != ""
+
 - name: remove software 
   yum: "name={{ item }} state=absent"
   with_items: remove_packages | default({})


### PR DESCRIPTION
This allows one to define array for all nodes (login+compute+other) while the array unconfigured_packages can be used to defined packages per type of nodes.
