### PR TITLE
allow to add own repositories via group_vars

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -5,6 +5,15 @@
   yum: name={{ item }} state=present
   with_items: "{{ centos_releases | default({}) }}"
 
+- name: add local defined yum repositories
+  yum_repository:
+    name="{{ item.name }}"
+    description="{{ item.name }}"
+    baseurl={{ item.url }}
+    gpgkey={{ item.gpgkey }}
+    gpgcheck="yes"
+  with_items: "{{ yum_repos | default({}) }}"
+
 - name: always install libselinux-python without it ansible facts cannot tell if selinux is enabled
   yum: name=libselinux-python state=present
 


### PR DESCRIPTION
This would allow one to define e.g. local repository for nodes. Useful for instance if using mellanox infiniband that ships rpms directly as a local repository. By default does not add anything if no entry is added to group_vars. 